### PR TITLE
Define query equality.

### DIFF
--- a/lib/olaf/query_definition.rb
+++ b/lib/olaf/query_definition.rb
@@ -45,6 +45,10 @@ module Olaf
       }
     end
 
+    def ==(other)
+      self.class == other.class && self.variables == other.variables
+    end
+
     def defined_arguments
       self.class.arguments.keys
     end

--- a/test/olaf/query_definition_test.rb
+++ b/test/olaf/query_definition_test.rb
@@ -108,4 +108,22 @@ class QueryDefinitionTest < Test::Unit::TestCase
 
     assert_equal @instance.undefined_arguments, [:id]
   end
+
+  def test_equals_return_false_when_class_is_different
+    @other_query = Class.new.include(Olaf::QueryDefinition)
+
+    assert @query.new != @other_query.new
+  end
+
+  def test_equals_return_false_when_same_class_but_different_variables
+    @query.argument :arg1
+
+    assert @query.new(arg1: 1) != @query.new(arg1: 2)
+  end
+
+  def test_equals_return_true_when_same_class_and_same_variables
+    @query.argument :arg1
+
+    assert_equal @query.new(arg1: 1), @query.new(arg1: 1)
+  end
 end


### PR DESCRIPTION
This will be useful for tests when we want to compare if a query was executed or not, without actually having the exact same object.

Also, `equals` is part of the identity of an object.