### PR TITLE
Capture unknown arguments

### DIFF
--- a/lib/olaf/errors.rb
+++ b/lib/olaf/errors.rb
@@ -23,6 +23,12 @@ module Olaf
     end
   end
 
+  class UnknownArgumentsError < StandardError
+    def initialize(olaf_query)
+      super("Unknown arguments: #{olaf_query.unknown_arguments}")
+    end
+  end
+
   class QueryExecutionError < StandardError
     attr_reader :metadata
 

--- a/test/olaf/query_definition_test.rb
+++ b/test/olaf/query_definition_test.rb
@@ -38,6 +38,16 @@ class QueryDefinitionTest < Test::Unit::TestCase
     end
   end
 
+  def test_prepare_fails_with_unknown_arguments
+    @query.template File.join(File.dirname(__FILE__), '../fixtures/query_with_arguments.sql')
+    @query.argument :id
+    @query.argument :not_in_sql
+
+    assert_raise Olaf::UnknownArgumentsError do
+      @query.new(id: 1, not_in_sql: 123).prepare
+    end
+  end
+
   def test_prepare_fills_sql_template
     @query.template File.join(File.dirname(__FILE__), '../fixtures/query_with_arguments.sql')
     @query.argument :id


### PR DESCRIPTION
When a query object declares an argument that is not defined in the template,
it must be considered as an error.

We should think the Olaf as a Bijective function between the a Ruby object and
a SQL template.