### PR TITLE
46312 update ruby cimg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,18 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@1.1.1
+  ruby: cimg/ruby@1.1.1
 
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.6.3-stretch-node
+      - image: cimg/ruby:2.6.3-node
 
     steps:
       - checkout
+      - run: sudo apt-get update
       - run: sudo apt-get install unixodbc-dev
+      - run: sudo apt-get autoclean
+      - run: sudo apt-get clean
       - run: gem install bundler
       - run: bundle install
       - run: rake test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,11 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.6-node
+      - image: circleci/ruby:2.6.3-stretch-node
 
     steps:
-      - run: echo  test
       - checkout
-      - run: sudo apt-get update && sudo apt-get install unixodbc-dev && sudo apt-get clean
+      - run: sudo apt-get install unixodbc-dev
       - run: gem install bundler
       - run: bundle install
       - run: rake test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ orbs:
 
 jobs:
   build:
-    environment: *environment
     executor: carwow/ruby
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,13 @@
 version: 2.1
 orbs:
   ruby: cimg/ruby@1.1.1
+  buildevents: honeycombio/buildevents@0.5
+  carwow: carwow/carwow-orb@0.4
 
 jobs:
   build:
-    docker:
-      - image: cimg/ruby:2.6.3-node
-
+    environment: *environment
+    executor: carwow/ruby
     steps:
       - checkout
       - run: sudo apt-get update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - image: cimg/ruby:2.6-node
 
     steps:
+      - run: echo  test
       - checkout
       - run: sudo apt-get update && sudo apt-get install unixodbc-dev && sudo apt-get clean
       - run: gem install bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.6-stretch-node
+      - image: cimg/ruby:2.6-node
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby: cimg/ruby@1.1.1
+  ruby: circleci/ruby@1.1.1
   buildevents: honeycombio/buildevents@0.5
   carwow: carwow/carwow-orb@0.4
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.6.3-stretch-node
+      - image: cimg/ruby:2.6-stretch-node
 
     steps:
       - checkout
-      - run: sudo apt-get install unixodbc-dev
+      - run: sudo apt-get update && sudo apt-get install unixodbc-dev && sudo apt-get clean
       - run: gem install bundler
       - run: bundle install
       - run: rake test

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 [![Gem Version](https://badge.fury.io/rb/olaf.svg)](https://badge.fury.io/rb/olaf)
 [![CircleCI](https://circleci.com/gh/carwow/olaf.svg?style=shield&circle-token=:circle-ci-badge-token)](https://circleci.com/gh/carwow/olaf)
 
-
-
 Olaf is a small Ruby wrapper for Snowflake queries.
 
 ![Olaf](https://user-images.githubusercontent.com/56375/96335285-8c86f080-106f-11eb-9489-999a884f1246.jpg)


### PR DESCRIPTION
source: [Kanbanize](https://carwow.kanbanize.com/ctrl_board/53/cards/46312/details/)
source: [CircleCI Run](todo)
source: [CircleCI Docker Images](https://circleci.com/developer/images/image/cimg/ruby)

This PR changes the RubyRubyRuby image from `circleci/ruby:2.6.3-stretch-node` to carwow RubyRubyRuby