### PR TITLE
Update from legacy circleci images to cimg.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - checkout
-      - run: sudo apt-get install unixodbc-dev
+      - run: sudo apt-get update && sudo apt-get install -y unixodbc-dev
       - run: bundle install
       - run: rake test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,4 +24,4 @@ workflows:
       - build:
           matrix:
             parameters:
-              ruby: ['2.7', '3.0']
+              ruby: ['2.6', '2.7', '3.0', '3.1']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get install unixodbc-dev
-      - run: gem install bundler
       - run: bundle install
       - run: rake test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,14 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@1.1.1
+  ruby: circleci/ruby@1.7.1
 
 jobs:
   build:
+    parameters:
+      ruby:
+        type: string
     docker:
-      - image: circleci/ruby:2.6.3-stretch-node
+      - image: cimg/ruby:<< parameters.ruby >>
 
     steps:
       - checkout
@@ -18,4 +21,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
+      - build:
+          matrix:
+            parameters:
+              ruby: ['2.7', '3.0']


### PR DESCRIPTION
The circle ci image being used is being [deprecated](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034).

This simply upgrades to using the latest ruby orb and now runs against ruby versions '2.6', '2.7', '3.0', '3.1' using the newer [convenience images](https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/) from circleci.